### PR TITLE
Ant 2816 persist custom columns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-autoql",
-  "version": "8.6.9",
+  "version": "8.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-autoql",
-      "version": "8.6.9",
+      "version": "8.7.0",
       "license": "ISC",
       "dependencies": {
         "@react-icons/all-files": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-autoql",
-  "version": "8.6.9",
+  "version": "8.7.0",
   "description": "React Widget Library",
   "main": "dist/autoql.cjs.js",
   "module": "dist/autoql.esm.js",

--- a/src/components/AddColumnBtn/CustomColumnModal.js
+++ b/src/components/AddColumnBtn/CustomColumnModal.js
@@ -132,18 +132,6 @@ export default class CustomColumnModal extends React.Component {
   }
 
   componentDidUpdate = (prevProps, prevState) => {
-    if (this.state.columnName && this.state.columnName !== prevState.columnName) {
-      const name = this.state.columnName
-      this.newColumn.display_name = name
-      this.newColumn.title = name
-
-      // Debounce change since column update is expensive
-      clearTimeout(this.debounceTimer)
-      this.debounceTimer = setTimeout(() => {
-        this.tableRef?.updateColumn?.(this.newColumn.field, this.newColumn)
-      }, 500)
-    }
-
     // Update column mutator is function changed
     if (!deepEqual(this.state.columnFn, prevState.columnFn) || this.state.columnType !== prevState.columnType) {
       setTimeout(() => {
@@ -228,7 +216,7 @@ export default class CustomColumnModal extends React.Component {
       if (col.field === this.newColumn?.field) {
         const newColFormatted = new ColumnObj(
           this.getColumnParamsForTabulator({
-            ...this.getRawColumnParams(columnForFn),
+            ...this.getRawColumnParams(columnForFn, newFnSummary),
             ...newParams,
             id: this.props.initialColumn?.id,
             custom: true,

--- a/src/components/AddColumnBtn/CustomColumnModal.js
+++ b/src/components/AddColumnBtn/CustomColumnModal.js
@@ -126,9 +126,9 @@ export default class CustomColumnModal extends React.Component {
     dataFormatting: dataFormattingDefault,
     enableWindowFunctions: false,
 
-    onAddColumn: () => {},
-    onUpdateColumn: () => {},
-    onClose: () => {},
+    onAddColumn: () => { },
+    onUpdateColumn: () => { },
+    onClose: () => { },
   }
 
   componentDidUpdate = (prevProps, prevState) => {
@@ -249,15 +249,40 @@ export default class CustomColumnModal extends React.Component {
     this.setState({ columns: newColumns })
   }
 
+  buildProtoTableColumn = (customColumn) => {
+    if (customColumn?.columnFnArray) {
+      let protoTableColumn = ''
+      for (const columnFn of customColumn?.columnFnArray) {
+        if (columnFn?.type === 'column') {
+          protoTableColumn += columnFn?.column?.name
+        } else if (columnFn?.type === 'operator') {
+          protoTableColumn += this.OPERATORS[columnFn?.value]?.js
+        } else if (columnFn?.type === 'number') {
+          protoTableColumn += columnFn?.value || 0
+        } else if (columnFn?.type === 'function') {
+          protoTableColumn += columnFn?.value || ''
+        } else {
+          console.error('Unknown columnFn type')
+        }
+        protoTableColumn += ' '
+      }
+
+      return protoTableColumn
+    }
+    return ''
+  }
+
   onUpdateColumnConfirm = () => {
     const newColumn = _cloneDeep(this.newColumn)
     newColumn.id = this.props.initialColumn?.id
-    this.props.onUpdateColumn(newColumn)
+    const protoTableColumn = this.buildProtoTableColumn(newColumn)
+    this.props.onUpdateColumn({ ...newColumn, table_column: protoTableColumn })
   }
 
   onAddColumnConfirm = () => {
     const newColumn = _cloneDeep(this.newColumn)
-    this.props.onAddColumn(newColumn)
+    const protoTableColumn = this.buildProtoTableColumn(newColumn)
+    this.props.onAddColumn({ ...newColumn, table_column: protoTableColumn })
   }
 
   changeChunkValue = (value, type, i) => {
@@ -437,8 +462,8 @@ export default class CustomColumnModal extends React.Component {
         focusOnMount
         label='Column Name'
         placeholder='eg. "Difference"'
-        value={this.state.columnName}
-        onChange={(e) => this.setState({ columnName: e.target.value })}
+        value={this.newColumn?.fnSummary || this.state.columnName}
+        disabled={true}
       />
     )
   }
@@ -451,6 +476,7 @@ export default class CustomColumnModal extends React.Component {
       <Select
         label='Formatting'
         className='custom-column-builder-type-selector'
+        fullWidth={true}
         options={[
           {
             value: 'auto',

--- a/src/components/ChataTable/ChataTable.js
+++ b/src/components/ChataTable/ChataTable.js
@@ -147,7 +147,6 @@ export default class ChataTable extends React.Component {
     keepScrolledRight: PropTypes.bool,
     allowCustomColumns: PropTypes.bool,
     onCustomColumnChange: PropTypes.func,
-    onCustomColumnDelete: PropTypes.func,
     enableContextMenu: PropTypes.bool,
   }
 
@@ -168,15 +167,14 @@ export default class ChataTable extends React.Component {
     keepScrolledRight: false,
     allowCustomColumns: true,
     enableContextMenu: true,
-    onFilterCallback: () => {},
-    onSorterCallback: () => {},
-    onTableParamsChange: () => {},
-    onCellClick: () => {},
-    onErrorCallback: () => {},
-    onNewData: () => {},
-    updateColumns: () => {},
-    onCustomColumnChange: () => {},
-    onCustomColumnDelete: () => {},
+    onFilterCallback: () => { },
+    onSorterCallback: () => { },
+    onTableParamsChange: () => { },
+    onCellClick: () => { },
+    onErrorCallback: () => { },
+    onNewData: () => { },
+    updateColumns: () => { },
+    onCustomColumnChange: () => { },
   }
 
   componentDidMount = () => {
@@ -1074,9 +1072,7 @@ export default class ChataTable extends React.Component {
       (select) => select.columns[0] !== column.name,
     )
 
-    if (column.custom) {
-      this.props.onCustomColumnDelete(column)
-    } else if (currentAdditionalSelectColumns?.length !== newAdditionalSelectColumns?.length) {
+    if (currentAdditionalSelectColumns?.length !== newAdditionalSelectColumns?.length) {
       this.setPageLoading(true)
       this.queryFn({ newColumns: newAdditionalSelectColumns })
         .then((response) => {

--- a/src/components/Dashboard/DashboardTile/DashboardTile.js
+++ b/src/components/Dashboard/DashboardTile/DashboardTile.js
@@ -128,15 +128,15 @@ export class DashboardTile extends React.Component {
     notExecutedText: 'Hit "Execute" to run this dashboard',
     autoChartAggregations: true,
     cancelQueriesOnUnmount: true,
-    deleteTile: () => {},
-    onErrorCallback: () => {},
-    onSuccessCallback: () => {},
-    onCSVDownloadStart: () => {},
-    onCSVDownloadProgress: () => {},
-    onCSVDownloadFinish: () => {},
-    onTouchStart: () => {},
-    onTouchEnd: () => {},
-    setParamsForTile: () => {},
+    deleteTile: () => { },
+    onErrorCallback: () => { },
+    onSuccessCallback: () => { },
+    onCSVDownloadStart: () => { },
+    onCSVDownloadProgress: () => { },
+    onCSVDownloadFinish: () => { },
+    onTouchStart: () => { },
+    onTouchEnd: () => { },
+    setParamsForTile: () => { },
   }
 
   componentDidMount = () => {
@@ -351,7 +351,6 @@ export class DashboardTile extends React.Component {
       dataConfig: queryChanged ? undefined : this.props.tile.dataConfig,
       skipQueryValidation: skipValidation,
       columns: queryChanged ? undefined : this.props.tile.columns,
-      customColumns: queryChanged ? undefined : this.props.tile.customColumns,
       defaultSelectedSuggestion: undefined,
       queryValidationSelections,
     })
@@ -727,7 +726,6 @@ export class DashboardTile extends React.Component {
   onDataConfigChange = (dataConfig) => this.debouncedSetParamsForTile({ dataConfig })
   onDisplayTypeChange = (displayType) => this.debouncedSetParamsForTile({ displayType })
   onBucketSizeChange = (bucketSize) => this.debouncedSetParamsForTile({ bucketSize })
-  onCustomColumnUpdate = (customColumns) => this.debouncedSetParamsForTile({ customColumns })
 
   onColumnChange = (columns, columnSelects, queryResponse, dataConfig) => {
     this.debouncedSetParamsForTile({ columnSelects, queryResponse, dataConfig })
@@ -797,9 +795,8 @@ export class DashboardTile extends React.Component {
           {this.renderBottomResponse()}
           {this.props.isEditing && (
             <div
-              className={`split-view-query-btn-container react-autoql-toolbar ${
-                this.state.isSecondQueryInputOpen ? 'open' : ''
-              }`}
+              className={`split-view-query-btn-container react-autoql-toolbar ${this.state.isSecondQueryInputOpen ? 'open' : ''
+                }`}
             >
               <div
                 className='react-autoql-toolbar viz-toolbar split-view-btn split-view-query-btn react-autoql-toolbar-btn'
@@ -1144,8 +1141,6 @@ export class DashboardTile extends React.Component {
         onPageSizeChange: this.onPageSizeChange,
         onBucketSizeChange: this.onBucketSizeChange,
         bucketSize: this.props.tile.bucketSize,
-        onCustomColumnUpdate: this.onCustomColumnUpdate,
-        customColumns: this.props.tile.customColumns,
       },
       vizToolbarProps: {
         ref: (r) => (this.vizToolbarRef = r),
@@ -1224,8 +1219,6 @@ export class DashboardTile extends React.Component {
         onBucketSizeChange: this.onSecondBucketSizeChange,
         onColumnChange: this.onSecondColumnChange,
         bucketSize: this.props.tile.secondBucketSize,
-        onCustomColumnUpdate: this.onSecondCustomColumnUpdate,
-        customColumns: this.props.tile.secondCustomColumns,
       },
       vizToolbarProps: {
         ref: (r) => (this.secondVizToolbarRef = r),

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -36,6 +36,7 @@ export default class Input extends React.Component {
     focusOnMount: PropTypes.bool,
     showArrow: PropTypes.bool,
     showSpinWheel: PropTypes.bool,
+    disabled: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -50,6 +51,7 @@ export default class Input extends React.Component {
     focusOnMount: false,
     showArrow: undefined,
     showSpinWheel: true,
+    disabled: false,
   }
 
   componentDidMount = () => {
@@ -234,6 +236,7 @@ export default class Input extends React.Component {
       showSpinWheel,
       showArrow,
       selectLocation,
+      disabled,
       ...nativeProps
     } = this.props
 
@@ -282,6 +285,7 @@ export default class Input extends React.Component {
                   onFocus={this.onFocus}
                   onBlur={this.onBlur}
                   style={this.props.inputStyle}
+                  disabled={disabled}
                 />
                 {icon && (
                   <Icon className={`react-autoql-input-icon ${this.state.focused ? ' focus' : ''}`} type={icon} />

--- a/src/components/Notifications/DataAlertModal/DataAlertModal.js
+++ b/src/components/Notifications/DataAlertModal/DataAlertModal.js
@@ -76,16 +76,16 @@ class DataAlertModal extends React.Component {
 
   static defaultProps = {
     authentication: authenticationDefault,
-    onSave: () => {},
-    onErrorCallback: () => {},
+    onSave: () => { },
+    onErrorCallback: () => { },
     currentDataAlert: undefined,
     dataAlertType: CONTINUOUS_TYPE,
     isVisible: false,
     allowDelete: true,
-    onClose: () => {},
-    onSuccessAlert: () => {},
-    onClosed: () => {},
-    onOpened: () => {},
+    onClose: () => { },
+    onSuccessAlert: () => { },
+    onClosed: () => { },
+    onOpened: () => { },
     enableQueryValidation: true,
     dataFormatting: dataFormattingDefault,
     autoQLConfig: autoQLConfigDefault,
@@ -230,6 +230,7 @@ class DataAlertModal extends React.Component {
               condition: EXISTS_TYPE,
               term_value: query,
               user_selection: queryResponse?.data?.data?.fe_req?.disambiguation,
+              additional_selects: queryResponse?.data?.data?.fe_req?.additional_selects || [],
             },
           ]
         }

--- a/src/components/Notifications/RuleSimple/RuleSimple.js
+++ b/src/components/Notifications/RuleSimple/RuleSimple.js
@@ -196,11 +196,11 @@ export default class RuleSimple extends React.Component {
   static defaultProps = {
     authentication: authenticationDefault,
     ruleId: undefined,
-    onUpdate: () => {},
+    onUpdate: () => { },
     initialData: undefined,
     queryResponse: undefined,
     queryResultMetadata: undefined,
-    onLastInputEnterPress: () => {},
+    onLastInputEnterPress: () => { },
     dataFormatting: dataFormattingDefault,
   }
 
@@ -338,6 +338,7 @@ export default class RuleSimple extends React.Component {
     const userSelection = this.props.queryResponse?.data?.data?.fe_req?.disambiguation
     const tableFilters = this.state.queryFilters?.filter((f) => f.type === 'table')
     const lockedFilters = this.state.queryFilters?.filter((f) => f.type === 'locked')
+    const additionalSelects = this.props.queryResponse?.data?.data?.fe_req?.additional_selects || []
 
     let firstQueryJoinColumnName =
       this.props.queryResponse?.data?.data?.columns[this.state.firstQueryGroupableColumnIndex]?.name
@@ -366,6 +367,7 @@ export default class RuleSimple extends React.Component {
         filters: tableFilters,
         session_filter_locks: lockedFilters,
         join_columns: firstQueryJoinColumns.length === 0 ? this.state.firstQueryJoinColumns : firstQueryJoinColumns,
+        additional_selects: additionalSelects,
       },
     ]
 

--- a/src/components/QueryOutput/QueryOutput.js
+++ b/src/components/QueryOutput/QueryOutput.js
@@ -477,7 +477,9 @@ export class QueryOutput extends React.Component {
       if (referenceIdNumber >= 200 && referenceIdNumber < 300) {
         return false
       }
-    } catch (error) { }
+    } catch (error) {
+      console.error(error)
+    }
     return true
   }
 

--- a/src/components/QueryOutput/QueryOutput.js
+++ b/src/components/QueryOutput/QueryOutput.js
@@ -30,9 +30,6 @@ import {
   getNumberOfGroupables,
   deepEqual,
   isSingleValueResponse,
-  isNumber,
-  hasNumberColumn,
-  hasStringColumn,
   removeElementAtIndex,
   isListQuery,
   GENERAL_QUERY_ERROR,
@@ -66,7 +63,6 @@ import {
   ColumnTypes,
   createMutatorFn,
   formatQueryColumns,
-  DisplayTypes,
   isColumnIndexConfigValid,
 } from 'autoql-fe-utils'
 
@@ -265,18 +261,18 @@ export class QueryOutput extends React.Component {
     bucketSize: undefined,
     allowColumnAddition: false,
     enableTableContextMenu: true,
-    onTableConfigChange: () => {},
-    onAggConfigChange: () => {},
-    onQueryValidationSelectOption: () => {},
-    onErrorCallback: () => {},
-    onDrilldownStart: () => {},
-    onDrilldownEnd: () => {},
-    onColumnChange: () => {},
-    onPageSizeChange: () => {},
-    onMount: () => {},
-    onBucketSizeChange: () => {},
-    onNewData: () => {},
-    onCustomColumnUpdate: () => {},
+    onTableConfigChange: () => { },
+    onAggConfigChange: () => { },
+    onQueryValidationSelectOption: () => { },
+    onErrorCallback: () => { },
+    onDrilldownStart: () => { },
+    onDrilldownEnd: () => { },
+    onColumnChange: () => { },
+    onPageSizeChange: () => { },
+    onMount: () => { },
+    onBucketSizeChange: () => { },
+    onNewData: () => { },
+    onCustomColumnUpdate: () => { },
   }
 
   componentDidMount = () => {
@@ -450,8 +446,7 @@ export class QueryOutput extends React.Component {
 
   displayTypeInvalidWarning = (displayType) => {
     console.warn(
-      `Initial display type "${this.props.initialDisplayType}" provided is not valid for this dataset. Using ${
-        displayType || this.state.displayType
+      `Initial display type "${this.props.initialDisplayType}" provided is not valid for this dataset. Using ${displayType || this.state.displayType
       } instead.`,
     )
   }
@@ -516,7 +511,7 @@ export class QueryOutput extends React.Component {
     // Remove mutator now that new cells have been defined
     const newColumns = [
       ...nonCustomColumns,
-      ...customColsFormatted.map((col) => {
+      ...customColsFormatted.map((col) => { // remove this or whole function
         const newCol = _cloneDeep(col)
         newCol.mutator = undefined
         return newCol
@@ -581,7 +576,7 @@ export class QueryOutput extends React.Component {
       if (referenceIdNumber >= 200 && referenceIdNumber < 300) {
         return false
       }
-    } catch (error) {}
+    } catch (error) { }
     return true
   }
 
@@ -835,9 +830,8 @@ export class QueryOutput extends React.Component {
       <div className='single-value-response-flex-container'>
         <div className='single-value-response-container'>
           <a
-            className={`single-value-response ${
-              getAutoQLConfig(this.props.autoQLConfig).enableDrilldowns ? ' with-drilldown' : ''
-            }`}
+            className={`single-value-response ${getAutoQLConfig(this.props.autoQLConfig).enableDrilldowns ? ' with-drilldown' : ''
+              }`}
             onClick={() => {
               this.processDrilldown({ groupBys: [], supportedByAPI: true })
             }}
@@ -2388,8 +2382,8 @@ export class QueryOutput extends React.Component {
       })
         .then((response) => {
           if (response?.data?.data?.rows) {
-            const newResponse = this.getNewResponseWithCustomColumns(response)
-            this.updateColumnsAndData(newResponse)
+            // const newResponse = this.getNewResponseWithCustomColumns(response)
+            this.updateColumnsAndData(response)
           } else {
             throw new Error('New column addition failed')
           }
@@ -2417,7 +2411,10 @@ export class QueryOutput extends React.Component {
       customColumns.push(newColumn)
     }
 
-    this.setState({ customColumns })
+    if (newColumn?.table_column) {
+      this.onAddColumnClick(newColumn)
+    }
+    // this.setState({ customColumns })
   }
 
   renderAddColumnBtn = () => {
@@ -2822,9 +2819,8 @@ export class QueryOutput extends React.Component {
 
   renderFooter = () => {
     const shouldRenderRT = this.shouldRenderReverseTranslation()
-    const footerClassName = `query-output-footer ${!shouldRenderRT ? 'no-margin' : ''} ${
-      this.props.reverseTranslationPlacement
-    }`
+    const footerClassName = `query-output-footer ${!shouldRenderRT ? 'no-margin' : ''} ${this.props.reverseTranslationPlacement
+      }`
 
     return <div className={footerClassName}>{shouldRenderRT && this.renderReverseTranslation()}</div>
   }


### PR DESCRIPTION
- update queryOutput, chataTable, customColumnModal, RuleSimple, and Data Alert Modal components to allow for custom columns to be created, generated and persisted as expected with BE support. 
- Persist the custom columns
- Ability to create alerts based on custom columns 
- Ability to delete
- Ability to create a custom column from other custom columns