### PR TITLE
Ant 2816 persist custom columns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "react-autoql",
-  "version": "8.7.2",
+  "version": "8.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-autoql",
-      "version": "8.7.2",
+      "version": "8.7.3",
       "license": "ISC",
       "dependencies": {
         "@react-icons/all-files": "^4.1.0",
-        "autoql-fe-utils": "1.5.1",
+        "autoql-fe-utils": "1.6.0",
         "axios": "^1.4.0",
         "classnames": "^2.5.1",
         "d3-array": "^2.3.3",
@@ -5185,9 +5185,9 @@
       }
     },
     "node_modules/autoql-fe-utils": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/autoql-fe-utils/-/autoql-fe-utils-1.5.1.tgz",
-      "integrity": "sha512-syeUay3/7wr++kE6K74+2J+g5UXxYwcbg3Z4M7ecxmp3kP3Pit5hFWs8hjH7QiF05Wndsnsso/MmRRsJJPKEwA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/autoql-fe-utils/-/autoql-fe-utils-1.6.0.tgz",
+      "integrity": "sha512-9ZJmYNBELprR7NaqQs1HVlqKVVFKpQ15Cnd0+Fc8XNPcggfZRdAPYQhfQNmR2FiH2sBL98AXuDOlUeU01odY7Q==",
       "dependencies": {
         "@types/lodash": "^4.14.195",
         "axios": "^1.4.0",
@@ -22483,9 +22483,9 @@
       }
     },
     "autoql-fe-utils": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/autoql-fe-utils/-/autoql-fe-utils-1.5.1.tgz",
-      "integrity": "sha512-syeUay3/7wr++kE6K74+2J+g5UXxYwcbg3Z4M7ecxmp3kP3Pit5hFWs8hjH7QiF05Wndsnsso/MmRRsJJPKEwA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/autoql-fe-utils/-/autoql-fe-utils-1.6.0.tgz",
+      "integrity": "sha512-9ZJmYNBELprR7NaqQs1HVlqKVVFKpQ15Cnd0+Fc8XNPcggfZRdAPYQhfQNmR2FiH2sBL98AXuDOlUeU01odY7Q==",
       "requires": {
         "@types/lodash": "^4.14.195",
         "axios": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-autoql",
-  "version": "8.7.3",
+  "version": "8.7.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-autoql",
-      "version": "8.7.3",
+      "version": "8.7.4",
       "license": "ISC",
       "dependencies": {
         "@react-icons/all-files": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-autoql",
-  "version": "8.7.3",
+  "version": "8.7.4",
   "description": "React Widget Library",
   "main": "dist/autoql.cjs.js",
   "module": "dist/autoql.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-autoql",
-  "version": "8.7.2",
+  "version": "8.7.3",
   "description": "React Widget Library",
   "main": "dist/autoql.cjs.js",
   "module": "dist/autoql.esm.js",
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@react-icons/all-files": "^4.1.0",
-    "autoql-fe-utils": "1.5.1",
+    "autoql-fe-utils": "1.6.0",
     "axios": "^1.4.0",
     "classnames": "^2.5.1",
     "d3-array": "^2.3.3",

--- a/src/components/AddColumnBtn/AddColumnBtn.js
+++ b/src/components/AddColumnBtn/AddColumnBtn.js
@@ -29,14 +29,16 @@ export class AddColumnBtnWithoutRef extends React.Component {
     onAddColumnClick: PropTypes.func,
     onCustomClick: PropTypes.func,
     tooltipID: PropTypes.string,
+    disableAddCustomColumnOption: PropTypes.bool,
   }
 
   static defaultProps = {
     queryResponse: undefined,
     allowCustom: true,
-    onAddColumnClick: () => {},
-    onCustomClick: () => {},
+    onAddColumnClick: () => { },
+    onCustomClick: () => { },
     tooltipID: undefined,
+    disableAddCustomColumnOption: false,
   }
 
   onAddColumnClick = (column, aggType, isHiddenColumn) => {
@@ -162,6 +164,11 @@ export class AddColumnBtnWithoutRef extends React.Component {
   }
 
   enableCustomOption = () => {
+
+    if (this.props.disableAddCustomColumnOption) {
+      return false
+    }
+
     let selectableColumnsForCustom
     try {
       selectableColumnsForCustom = getSelectableColumns(this.props.queryResponse?.data?.data?.columns)

--- a/src/components/ChataTable/ChataTable.js
+++ b/src/components/ChataTable/ChataTable.js
@@ -1069,7 +1069,9 @@ export default class ChataTable extends React.Component {
 
     const currentAdditionalSelectColumns = this.props.response?.data?.data?.fe_req?.additional_selects ?? []
     const newAdditionalSelectColumns = currentAdditionalSelectColumns?.filter(
-      (select) => select.columns[0] !== column.name,
+      (select) => {
+        return select?.columns[0]?.replace(/ /g, '') !== column?.name?.replace(/ /g, '')
+      },
     )
 
     if (currentAdditionalSelectColumns?.length !== newAdditionalSelectColumns?.length) {

--- a/src/components/DataMessenger/DataMessenger.js
+++ b/src/components/DataMessenger/DataMessenger.js
@@ -642,11 +642,12 @@ export class DataMessenger extends React.Component {
   renderHeaderTitle = () => {
     let title = ''
 
+    if (this.props?.autoQLConfig?.enableProjectSelect && this.props?.projectSelectList?.length > 0) {
+      return this.projectSelectorHeader()
+    }
+
     switch (this.state.activePage) {
       case 'data-messenger': {
-        if (this.props.autoQLConfig?.enableProjectSelect) {
-          return this.projectSelectorHeader()
-        }
         title = this.props.title
         break
       }

--- a/src/components/Notifications/DataAlertModal/DataAlertModal.js
+++ b/src/components/Notifications/DataAlertModal/DataAlertModal.js
@@ -576,7 +576,7 @@ class DataAlertModal extends React.Component {
 
   renderAlphaAlertsSettings = () => {
     return (
-      <CollapsableSection title='Additional Settings'>
+      <CollapsableSection title='Additional Settings' onToggle={() => { }} defaultCollapsed={true}>
         <AlphaAlertsSettings
           ref={(r) => (this.alphaAlertsSettingRef = r)}
           descriptionInput={this.state.descriptionInput}

--- a/src/components/QueryOutput/QueryOutput.js
+++ b/src/components/QueryOutput/QueryOutput.js
@@ -595,7 +595,7 @@ export class QueryOutput extends React.Component {
 
   getUpdatedCustomColumnSelects = (additionalSelects, columns) => {
     const customColumnSelects = []
-    for (let i = 0; i < columns.length; i++) {
+    for (let i = 0; i < columns?.length; i++) {
       const foundCustomSelect = additionalSelects?.find((select) => {
         return select?.columns?.[0]?.replace(/ /g, '') === columns?.[i].name?.replace(/ /g, '')
       })


### PR DESCRIPTION
- persist custom columns through data alerts, dashboards, and queries
- Allow for custom columns to edited 
- disabled custom columns on drilldowns till it is BE supported 