### PR TITLE
Custom columns bug fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@react-icons/all-files": "^4.1.0",
-        "autoql-fe-utils": "1.6.1",
+        "autoql-fe-utils": "1.6.2",
         "axios": "^1.4.0",
         "classnames": "^2.5.1",
         "d3-array": "^2.3.3",
@@ -5186,9 +5186,9 @@
       }
     },
     "node_modules/autoql-fe-utils": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/autoql-fe-utils/-/autoql-fe-utils-1.6.1.tgz",
-      "integrity": "sha512-1l/BSSHYNkWn1zGRhriH9xPiJqZTwfL9w77Ycu/8wwZjBKowBK5svlcUAOtHY4eyxTCFGzAVeE4dzE1qlSy33g==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/autoql-fe-utils/-/autoql-fe-utils-1.6.2.tgz",
+      "integrity": "sha512-VzcLOgNNrCbCoZShIC5X7SgCNHzSrtuuABz1ZGKt4tFThM9AjXu4jeavwHFOtnmh7wHjQICwey59C9UpHJ9Eug==",
       "dependencies": {
         "@types/lodash": "^4.14.195",
         "axios": "^1.4.0",
@@ -22524,9 +22524,9 @@
       }
     },
     "autoql-fe-utils": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/autoql-fe-utils/-/autoql-fe-utils-1.6.1.tgz",
-      "integrity": "sha512-1l/BSSHYNkWn1zGRhriH9xPiJqZTwfL9w77Ycu/8wwZjBKowBK5svlcUAOtHY4eyxTCFGzAVeE4dzE1qlSy33g==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/autoql-fe-utils/-/autoql-fe-utils-1.6.2.tgz",
+      "integrity": "sha512-VzcLOgNNrCbCoZShIC5X7SgCNHzSrtuuABz1ZGKt4tFThM9AjXu4jeavwHFOtnmh7wHjQICwey59C9UpHJ9Eug==",
       "requires": {
         "@types/lodash": "^4.14.195",
         "axios": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-autoql",
-  "version": "8.8.7",
+  "version": "8.8.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-autoql",
-      "version": "8.8.7",
+      "version": "8.8.8",
       "license": "ISC",
       "dependencies": {
         "@react-icons/all-files": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@react-icons/all-files": "^4.1.0",
-    "autoql-fe-utils": "1.6.1",
+    "autoql-fe-utils": "1.6.2",
     "axios": "^1.4.0",
     "classnames": "^2.5.1",
     "d3-array": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-autoql",
-  "version": "8.8.7",
+  "version": "8.8.8",
   "description": "React Widget Library",
   "main": "dist/autoql.cjs.js",
   "module": "dist/autoql.esm.js",

--- a/src/components/AddColumnBtn/CustomColumnModal.scss
+++ b/src/components/AddColumnBtn/CustomColumnModal.scss
@@ -59,6 +59,7 @@
           display: flex;
           flex-direction: row;
           flex-wrap: wrap;
+          overflow: auto;
         }
       }
 
@@ -80,6 +81,7 @@
 
         .react-autoql-formula-builder-calculator-buttons-container {
           overflow: auto;
+          max-height: 250px;
 
           .react-autoql-btn {
             white-space: pre;

--- a/src/components/ChataTable/ChataTable.js
+++ b/src/components/ChataTable/ChataTable.js
@@ -1200,7 +1200,7 @@ export default class ChataTable extends React.Component {
         <CustomColumnModal
           {...this.props}
           isOpen={this.state.isCustomColumnPopoverOpen}
-          onClose={() => this.setState({ isCustomColumnPopoverOpen: false })}
+          onClose={() => this.setState({ isCustomColumnPopoverOpen: false, activeCustomColumn: undefined })}
           tableRef={this.ref}
           aggConfig={this.props.aggConfig}
           queryResponse={this.props.response}

--- a/src/components/QueryOutput/QueryOutput.js
+++ b/src/components/QueryOutput/QueryOutput.js
@@ -62,6 +62,7 @@ import {
   setColumnVisibility,
   ColumnTypes,
   isColumnIndexConfigValid,
+  getCleanColumnName,
 } from 'autoql-fe-utils'
 
 import { Icon } from '../Icon'
@@ -424,8 +425,7 @@ export class QueryOutput extends React.Component {
 
   displayTypeInvalidWarning = (displayType) => {
     console.warn(
-      `Initial display type "${this.props.initialDisplayType}" provided is not valid for this dataset. Using ${
-        displayType || this.state.displayType
+      `Initial display type "${this.props.initialDisplayType}" provided is not valid for this dataset. Using ${displayType || this.state.displayType
       } instead.`,
     )
   }
@@ -761,9 +761,8 @@ export class QueryOutput extends React.Component {
       <div className='single-value-response-flex-container'>
         <div className='single-value-response-container'>
           <a
-            className={`single-value-response ${
-              getAutoQLConfig(this.props.autoQLConfig).enableDrilldowns ? ' with-drilldown' : ''
-            }`}
+            className={`single-value-response ${getAutoQLConfig(this.props.autoQLConfig).enableDrilldowns ? ' with-drilldown' : ''
+              }`}
             onClick={() => {
               this.processDrilldown({ groupBys: [], supportedByAPI: true })
             }}
@@ -1861,11 +1860,16 @@ export class QueryOutput extends React.Component {
         newCol.dateRange = dateRange
       }
 
-      if (additionalSelects?.length > 0) {
+      if (additionalSelects?.length > 0 && isColumnNumberType(newCol)) {
         const customSelect = additionalSelects.find((select) => {
           return select?.columns?.[0]?.replace(/ /g, '') === newCol?.name?.replace(/ /g, '')
         })
-        if (customSelect) {
+        const cleanName = getCleanColumnName(newCol?.name)
+        const availableSelect = this.queryResponse?.data?.data?.available_selects?.find((select) => {
+          return select?.table_column?.trim() === cleanName
+        })
+
+        if (customSelect && !availableSelect) {
           newCol.custom = true
         }
       }
@@ -2746,9 +2750,8 @@ export class QueryOutput extends React.Component {
 
   renderFooter = () => {
     const shouldRenderRT = this.shouldRenderReverseTranslation()
-    const footerClassName = `query-output-footer ${!shouldRenderRT ? 'no-margin' : ''} ${
-      this.props.reverseTranslationPlacement
-    }`
+    const footerClassName = `query-output-footer ${!shouldRenderRT ? 'no-margin' : ''} ${this.props.reverseTranslationPlacement
+      }`
 
     return <div className={footerClassName}>{shouldRenderRT && this.renderReverseTranslation()}</div>
   }


### PR DESCRIPTION
ANT-2910: disable Update/Save custom column in custom column modal when no formula has been inputed
ANT-2928: disable available_selects columns that are added to the query response from being edited in the edit Custom Column Modal 
ANT-2857: disable option to add custom columns to drilldown response 