### PR TITLE
Ant 3379 persist sort and filter data in dashboard tile 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-autoql",
-  "version": "8.10.1",
+  "version": "8.10.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-autoql",
-      "version": "8.10.1",
+      "version": "8.10.2",
       "license": "ISC",
       "dependencies": {
         "@react-icons/all-files": "4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "react-autoql",
-  "version": "8.9.8",
+  "version": "8.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-autoql",
-      "version": "8.9.8",
+      "version": "8.10.0",
       "license": "ISC",
       "dependencies": {
         "@react-icons/all-files": "4.1.0",
-        "autoql-fe-utils": "1.7.3",
+        "autoql-fe-utils": "1.7.4",
         "axios": "1.4.0",
         "caniuse-lite": "1.0.30001692",
         "classnames": "2.5.1",
@@ -4490,9 +4490,9 @@
       }
     },
     "node_modules/autoql-fe-utils": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/autoql-fe-utils/-/autoql-fe-utils-1.7.3.tgz",
-      "integrity": "sha512-V4AiR8Jpd3mOfh7g2GSYQYUHd1A5Gaoy9EWL9b3YV5ElkqXMO2I37vJLUKLfO9jEa1rStr79SamZ1VdmLbI8RQ==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/autoql-fe-utils/-/autoql-fe-utils-1.7.4.tgz",
+      "integrity": "sha512-F21GhwjmwxY1ZUTKrtD41Wgtkrmowt32GKpEHI0wGvnkVr8IN6+DINAz5V0dL8BOhT6A9DhFoHDzqTxtSyW8Wg==",
       "dependencies": {
         "@types/lodash": "^4.14.195",
         "axios": "^1.4.0",
@@ -20409,9 +20409,9 @@
       }
     },
     "autoql-fe-utils": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/autoql-fe-utils/-/autoql-fe-utils-1.7.3.tgz",
-      "integrity": "sha512-V4AiR8Jpd3mOfh7g2GSYQYUHd1A5Gaoy9EWL9b3YV5ElkqXMO2I37vJLUKLfO9jEa1rStr79SamZ1VdmLbI8RQ==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/autoql-fe-utils/-/autoql-fe-utils-1.7.4.tgz",
+      "integrity": "sha512-F21GhwjmwxY1ZUTKrtD41Wgtkrmowt32GKpEHI0wGvnkVr8IN6+DINAz5V0dL8BOhT6A9DhFoHDzqTxtSyW8Wg==",
       "requires": {
         "@types/lodash": "^4.14.195",
         "axios": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-autoql",
-  "version": "8.10.1",
+  "version": "8.10.2",
   "description": "React Widget Library",
   "main": "dist/autoql.cjs.js",
   "module": "dist/autoql.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-autoql",
-  "version": "8.9.8",
+  "version": "8.10.0",
   "description": "React Widget Library",
   "main": "dist/autoql.cjs.js",
   "module": "dist/autoql.esm.js",
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@react-icons/all-files": "4.1.0",
-    "autoql-fe-utils": "1.7.3",
+    "autoql-fe-utils": "1.7.4",
     "axios": "1.4.0",
     "caniuse-lite": "1.0.30001692",
     "classnames": "2.5.1",

--- a/src/components/ChatMessage/ChatMessage.js
+++ b/src/components/ChatMessage/ChatMessage.js
@@ -392,7 +392,6 @@ export default class ChatMessage extends React.Component {
           {hasRT ? (
             <div className='chat-message-rt-container'>
               <ReverseTranslation
-                ref={(r) => (this.rtRef = r)}
                 key={this.responseRef.queryResponse?.data?.data?.query_id}
                 authentication={this.props.authentication}
                 onValueLabelClick={this.props.onRTValueLabelClick}

--- a/src/components/ChataTable/ChataTable.js
+++ b/src/components/ChataTable/ChataTable.js
@@ -274,13 +274,15 @@ export default class ChataTable extends React.Component {
         }
       })
       this.setHeaderInputEventListeners()
-      this.setFilters()
+      this.setFilter()
+      this.setSorters()
       this.clearLoadingIndicators()
     }
 
     if (this.state.tabulatorMounted && !prevState.tabulatorMounted) {
       this.tableParams.filter = this.props?.initialTableParams?.filter
       this.setFilters(this.props?.initialTableParams?.filter)
+      this.setSorters(this.props?.initialTableParams?.sort)
       this.setHeaderInputEventListeners()
       if (!this.props.hidden) {
         this.setTableHeight()
@@ -580,15 +582,10 @@ export default class ChataTable extends React.Component {
   ajaxRequestFunc = async (props, params) => {
     if (this.useRemote === 'local') {
       const fullData = props.response?.data?.data?.rows || []
-
       // Initialize table with complete dataset
       this.ref?.tabulator?.setData(fullData)
-
-      //   return {
-      //     data: [], // Return empty since data is already set
-      //     last_page: 1,
-      //   }
     }
+
     const initialData = {
       rows: this.getRows(this.props, 1),
       page: 1,
@@ -629,6 +626,7 @@ export default class ChataTable extends React.Component {
         await currentEventLoopEnd()
 
         this.props.onTableParamsChange(params, nextTableParamsFormatted)
+
         this.props.onNewData(responseWrapper)
 
         const totalPages = this.getTotalPages(responseWrapper)
@@ -1057,8 +1055,8 @@ export default class ChataTable extends React.Component {
     this.setState({ dateRangeSelection })
   }
 
-  setSorters = () => {
-    const sorterValues = this.tableParams?.sort
+  setSorters = (newSorters) => {
+    const sorterValues = newSorters || this.tableParams?.sort
     this.settingSorters = true
 
     if (sorterValues) {

--- a/src/components/OptionsToolbar/OptionsToolbar.js
+++ b/src/components/OptionsToolbar/OptionsToolbar.js
@@ -458,10 +458,9 @@ export class OptionsToolbar extends React.Component {
                 <li
                   key={`custom-option-${i}`}
                   onClick={() => {
-                    this.setState({ activeMenu: undefined })
                     const responseRef = this.props.responseRef
                     const responseCopy = _cloneDeep(responseRef?.queryResponse)
-
+                    this.setState({ activeMenu: undefined })
                     option.callback?.({
                       query: responseRef?.queryResponse?.data?.data?.text,
                       queryResponse: responseCopy,
@@ -469,6 +468,9 @@ export class OptionsToolbar extends React.Component {
                       displayType: responseRef?.state?.displayType,
                       columnSelects: responseCopy?.data?.data?.fe_req?.additional_selects,
                       displayOverrides: responseCopy?.data?.data?.fe_req?.display_overrides,
+                      filters: responseCopy?.data?.data?.fe_req?.session_filter_locks,
+                      tableFilters: responseCopy?.data?.data?.fe_req?.filters,
+                      orders: responseCopy?.data?.data?.fe_req?.orders,
                       dataConfig: {
                         tableConfig: _cloneDeep(responseRef?.tableConfig),
                         pivotTableConfig: _cloneDeep(responseRef?.pivotTableConfig),


### PR DESCRIPTION
- pass filter, and sort data from dashboard to query
- update OptionToolbar to include filter and sort data when creating dashboard tile from DM
- pass intialTableParams from dashboard tile all the way through the ChataTable component
- Update to version 8.10.0 and autoql-fe-utils