### PR TITLE
fix: disable table vertical resize due to bugs, keep chart-only resize as originally requested

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-autoql",
-  "version": "8.12.2",
+  "version": "8.12.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-autoql",
-      "version": "8.12.2",
+      "version": "8.12.3",
       "license": "ISC",
       "dependencies": {
         "@react-icons/all-files": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-autoql",
-  "version": "8.12.2",
+  "version": "8.12.3",
   "description": "React Widget Library",
   "main": "dist/autoql.cjs.js",
   "module": "dist/autoql.esm.js",

--- a/src/components/QueryOutput/QueryOutput.js
+++ b/src/components/QueryOutput/QueryOutput.js
@@ -87,9 +87,8 @@ export class QueryOutput extends React.Component {
   constructor(props) {
     super(props)
     this.minWidth = props.minWidth || 400
-    const isNonTableNonChart =
-      !isChartType(this.getDisplayTypeFromInitial(props)) && !isTableType(this.getDisplayTypeFromInitial(props))
-    this.minHeight = isNonTableNonChart ? 80 : props.minHeight || 300
+    const isChart = isChartType(this.getDisplayTypeFromInitial(props))
+    this.minHeight = 300
     this.resizeMultiplier = props.resizeMultiplier || 1.5
     this.COMPONENT_KEY = uuid()
     this.QUERY_VALIDATION_KEY = uuid()
@@ -161,8 +160,7 @@ export class QueryOutput extends React.Component {
     }
 
     this.DEFAULT_TABLE_PAGE_SIZE = 100
-    const isTableOrChart = isTableType(displayType) || isChartType(displayType)
-    this.shouldEnableResize = props.enableResizing && isTableOrChart
+    this.shouldEnableResize = props.enableResizing && isChart
     this.state = {
       displayType,
       aggConfig: props.initialAggConfig,
@@ -337,8 +335,8 @@ export class QueryOutput extends React.Component {
       let shouldForceUpdate = false
 
       if (this.state.displayType !== prevState.displayType) {
-        const isTableOrChart = isTableType(this.state.displayType) || isChartType(this.state.displayType)
-        const shouldEnableResize = this.props.enableResizing && isTableOrChart
+        const isChart = isChartType(this.state.displayType)
+        const shouldEnableResize = this.props.enableResizing && isChart
 
         if (shouldEnableResize !== this.shouldEnableResize) {
           this.shouldEnableResize = shouldEnableResize
@@ -501,8 +499,8 @@ export class QueryOutput extends React.Component {
     if (!this.state.isResizing || !this.props.enableResizing) return
 
     const deltaY = (e.clientY - this.state.resizeStartY) * this.resizeMultiplier
-    const isNonTableNonChart = !isChartType(this.state.displayType) && !isTableType(this.state.displayType)
-    const effectiveMinHeight = isNonTableNonChart ? 80 : this.minHeight
+    const isChart = isChartType(this.state.displayType)
+    const effectiveMinHeight = isChart ? this.minHeight : 80
     const newHeight = Math.min(this.maxHeight, Math.max(effectiveMinHeight, this.state.resizeStartHeight + deltaY))
 
     this.setState({


### PR DESCRIPTION
fix: disable table vertical resize to prevent bugs, keep chart-only resize

Disable vertical resize functionality for table display types due to multiple
bugs occurring in different use cases. The original feature request was
specifically for chart display types, so restricting resize to charts only
maintains the intended functionality while avoiding table-related issues.

- Remove table from resize-enabled display types
- Keep resize functionality for chart display types only
- Adjust minHeight logic to account for chart-only resize
- Update event listener management for display type changes