### PR TITLE
set the max-height to 400px to hotfix the issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-autoql",
-  "version": "8.12.3",
+  "version": "8.12.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-autoql",
-      "version": "8.12.3",
+      "version": "8.12.5",
       "license": "ISC",
       "dependencies": {
         "@react-icons/all-files": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-autoql",
-  "version": "8.12.3",
+  "version": "8.12.5",
   "description": "React Widget Library",
   "main": "dist/autoql.cjs.js",
   "module": "dist/autoql.esm.js",

--- a/src/components/ChatMessage/ChatMessage.scss
+++ b/src/components/ChatMessage/ChatMessage.scss
@@ -177,7 +177,7 @@
       box-sizing: border-box;
       box-shadow: var(--react-autoql-box-shadow-1);
       &:not(.resizable) {
-        max-height: 300px;
+        max-height: 400px;
       }
       &.resizable {
         max-height: none;


### PR DESCRIPTION
Increased chat message bubble max-height from 300px to 400px for better table row visibility
Rationale:

- Historical consistency: We previously used 400px for a long time, which has proven to be the optimal height for chat message bubbles
- Improved table display: The increased height allows more table rows to be visible without too much scrolling for row number less and equal than 15, providing better data visibility and user experience
- Perfect chat bubble proportions: 400px maintains the ideal balance between content visibility and chat interface aesthetics
User experience: Users can see more data at a glance, reducing the need for scrolling within individual message bubbles