### PR TITLE
AQLP-130: Dashboard toolbar widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@react-icons/all-files": "4.1.0",
-        "autoql-fe-utils": "1.7.13",
+        "autoql-fe-utils": "1.7.14",
         "axios": "1.4.0",
         "caniuse-lite": "1.0.30001692",
         "classnames": "2.5.1",
@@ -4455,9 +4455,9 @@
       }
     },
     "node_modules/autoql-fe-utils": {
-      "version": "1.7.13",
-      "resolved": "https://registry.npmjs.org/autoql-fe-utils/-/autoql-fe-utils-1.7.13.tgz",
-      "integrity": "sha512-RvWpwySTT+7bLZXRozuIDjMPqPA9YeI0Tp2ZyUvHD1RJSzed5h4WqcLZ7fylNNDLdiGUhmlvuChyK7ra4Ivcyg==",
+      "version": "1.7.14",
+      "resolved": "https://registry.npmjs.org/autoql-fe-utils/-/autoql-fe-utils-1.7.14.tgz",
+      "integrity": "sha512-aIcPCA6NhO8oZrjp/XIs7Rlw7An3DhPy6QeqzhBUYtFoUVq6kiBZYo14PsuKtwTlpdw187XQANFRKkeK6MWEWg==",
       "dependencies": {
         "@types/lodash": "4.14.195",
         "axios": "1.4.0",
@@ -20303,9 +20303,9 @@
       }
     },
     "autoql-fe-utils": {
-      "version": "1.7.13",
-      "resolved": "https://registry.npmjs.org/autoql-fe-utils/-/autoql-fe-utils-1.7.13.tgz",
-      "integrity": "sha512-RvWpwySTT+7bLZXRozuIDjMPqPA9YeI0Tp2ZyUvHD1RJSzed5h4WqcLZ7fylNNDLdiGUhmlvuChyK7ra4Ivcyg==",
+      "version": "1.7.14",
+      "resolved": "https://registry.npmjs.org/autoql-fe-utils/-/autoql-fe-utils-1.7.14.tgz",
+      "integrity": "sha512-aIcPCA6NhO8oZrjp/XIs7Rlw7An3DhPy6QeqzhBUYtFoUVq6kiBZYo14PsuKtwTlpdw187XQANFRKkeK6MWEWg==",
       "requires": {
         "@types/lodash": "4.14.195",
         "axios": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@react-icons/all-files": "4.1.0",
-    "autoql-fe-utils": "1.7.13",
+    "autoql-fe-utils": "1.7.14",
     "axios": "1.4.0",
     "caniuse-lite": "1.0.30001692",
     "classnames": "2.5.1",

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -22,6 +22,7 @@ export class ButtonWithoutRef extends React.Component {
     border: PropTypes.bool,
     tooltip: PropTypes.string,
     icon: PropTypes.string,
+    iconOnly: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -34,6 +35,7 @@ export class ButtonWithoutRef extends React.Component {
     filled: false,
     border: true,
     icon: undefined,
+    iconOnly: false,
     onClick: () => {},
   }
 
@@ -86,7 +88,8 @@ export class ButtonWithoutRef extends React.Component {
             react-autoql-btn-${size}
             ${isDisabled ? ' disabled' : ''}
             ${this.props.border ? '' : 'btn-no-border'}
-            ${this.props.filled ? 'btn-filled' : ''}`}
+            ${this.props.filled ? 'btn-filled' : ''}
+            ${this.props.iconOnly ? 'icon-only' : ''}`}
           data-test='react-autoql-btn'
           data-multiline={this.props.multiline}
           style={{ ...this.props.style }}

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -61,7 +61,7 @@
   margin: 3px 3px;
 }
 .react-autoql-btn.react-autoql-btn-large {
-  padding: 10px 16px;
+  padding: 8px 16px;
   margin: 2px 5px;
 }
 

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -19,6 +19,20 @@
     }
   }
 
+  &.icon-only {
+    font-size: 1.2em;
+    border-radius: 50%;
+    width: 2em;
+    height: 2em;
+    margin: 4px 1px !important;
+    padding: 8px !important;
+
+    .react-autoql-btn-icon {
+      margin-right: 0;
+      margin-left: 0;
+    }
+  }
+
   .react-autoql-icon {
     display: flex;
   }
@@ -73,6 +87,8 @@
   background: var(--react-autoql-accent-color);
   border: 1px solid var(--react-autoql-accent-color);
   color: var(--react-autoql-text-color-accent);
+  box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14),
+    0px 1px 5px 0px rgba(0, 0, 0, 0.12);
   &:hover {
     opacity: 0.8;
   }
@@ -83,6 +99,8 @@
     color: var(--react-autoql-danger-color, var(--react-autoql-danger-color-default));
     border: 1px solid var(--react-autoql-danger-color, var(--react-autoql-danger-color-default));
     background: inherit;
+    box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14),
+      0px 1px 5px 0px rgba(0, 0, 0, 0.12);
 
     &:hover {
       background: var(--react-autoql-mask-color);

--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -709,6 +709,7 @@ class DashboardWithoutTheme extends React.Component {
           {this.props.showToolbar && (
             <DashboardToolbar
               isEditing={this.props.isEditing}
+              isEditable={this.props.isEditable}
               tooltipID={this.TOOLTIP_ID}
               title={this.props.title}
               onEditClick={this.props.startEditingCallback}

--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -80,6 +80,9 @@ class DashboardWithoutTheme extends React.Component {
     onCSVDownloadFinish: PropTypes.func,
     cancelQueriesOnUnmount: PropTypes.bool,
     startEditingCallback: PropTypes.func,
+    stopEditingCallback: PropTypes.func,
+    onSaveCallback: PropTypes.func,
+    onDeleteCallback: PropTypes.func,
   }
 
   static defaultProps = {
@@ -105,6 +108,9 @@ class DashboardWithoutTheme extends React.Component {
     onCSVDownloadProgress: () => {},
     onCSVDownloadFinish: () => {},
     startEditingCallback: () => {},
+    stopEditingCallback: () => {},
+    onSaveClick: () => {},
+    onDeleteCallback: () => {},
   }
 
   componentDidMount = () => {
@@ -698,7 +704,20 @@ class DashboardWithoutTheme extends React.Component {
     return (
       <ErrorBoundary>
         <>
-          <DashboardToolbar isEditing={this.props.isEditing} tooltipID={this.TOOLTIP_ID} title={this.props.title} />
+          <DashboardToolbar
+            isEditing={this.props.isEditing}
+            tooltipID={this.TOOLTIP_ID}
+            title={this.props.title}
+            onEditClick={this.props.startEditingCallback}
+            onCancelClick={this.props.stopEditingCallback}
+            onAddTileClick={this.addTile}
+            onUndoClick={this.undo}
+            onRedoClick={this.redo}
+            onRefreshClick={this.executeDashboard}
+            onSaveClick={this.props.onSaveCallback}
+            onDeleteClick={this.props.onDeleteCallback}
+            onRenameClick={this.props.onRenameCallback}
+          />
           <div
             ref={(ref) => (this.ref = ref)}
             className={`react-autoql-dashboard-container${this.props.isEditing ? ' edit-mode' : ''}`}

--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -83,6 +83,7 @@ class DashboardWithoutTheme extends React.Component {
     stopEditingCallback: PropTypes.func,
     onSaveCallback: PropTypes.func,
     onDeleteCallback: PropTypes.func,
+    showToolbar: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -101,6 +102,7 @@ class DashboardWithoutTheme extends React.Component {
     enableDynamicCharting: true,
     autoChartAggregations: true,
     cancelQueriesOnUnmount: false,
+    showToolbar: false,
     onErrorCallback: () => {},
     onSuccessCallback: () => {},
     onChange: () => {},
@@ -704,20 +706,22 @@ class DashboardWithoutTheme extends React.Component {
     return (
       <ErrorBoundary>
         <>
-          <DashboardToolbar
-            isEditing={this.props.isEditing}
-            tooltipID={this.TOOLTIP_ID}
-            title={this.props.title}
-            onEditClick={this.props.startEditingCallback}
-            onCancelClick={this.props.stopEditingCallback}
-            onAddTileClick={this.addTile}
-            onUndoClick={this.undo}
-            onRedoClick={this.redo}
-            onRefreshClick={this.executeDashboard}
-            onSaveClick={this.props.onSaveCallback}
-            onDeleteClick={this.props.onDeleteCallback}
-            onRenameClick={this.props.onRenameCallback}
-          />
+          {this.props.showToolbar && (
+            <DashboardToolbar
+              isEditing={this.props.isEditing}
+              tooltipID={this.TOOLTIP_ID}
+              title={this.props.title}
+              onEditClick={this.props.startEditingCallback}
+              onCancelClick={this.props.stopEditingCallback}
+              onAddTileClick={this.addTile}
+              onUndoClick={this.undo}
+              onRedoClick={this.redo}
+              onRefreshClick={this.executeDashboard}
+              onSaveClick={this.props.onSaveCallback}
+              onDeleteClick={this.props.onDeleteCallback}
+              onRenameClick={this.props.onRenameCallback}
+            />
+          )}
           <div
             ref={(ref) => (this.ref = ref)}
             className={`react-autoql-dashboard-container${this.props.isEditing ? ' edit-mode' : ''}`}

--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -16,6 +16,7 @@ import {
 
 import { Tooltip } from '../Tooltip'
 import DrilldownModal from './DrilldownModal'
+import { DashboardToolbar } from '../DashboardToolbar'
 import { DashboardTile } from './DashboardTile'
 import { ErrorBoundary } from '../../containers/ErrorHOC'
 
@@ -697,6 +698,7 @@ class DashboardWithoutTheme extends React.Component {
     return (
       <ErrorBoundary>
         <>
+          <DashboardToolbar isEditing={this.props.isEditing} tooltipID={this.TOOLTIP_ID} title={this.props.title} />
           <div
             ref={(ref) => (this.ref = ref)}
             className={`react-autoql-dashboard-container${this.props.isEditing ? ' edit-mode' : ''}`}

--- a/src/components/Dashboard/Dashboard.scss
+++ b/src/components/Dashboard/Dashboard.scss
@@ -2,7 +2,7 @@
   background: transparent;
   width: 100%;
   overflow: hidden;
-  padding-top: 3px;
+  margin-top: -18px;
 }
 
 .react-autoql-dashboard-container.edit-mode {

--- a/src/components/DashboardToolbar/DashboardToolbar.js
+++ b/src/components/DashboardToolbar/DashboardToolbar.js
@@ -145,23 +145,25 @@ export class DashboardToolbarWithoutRef extends React.Component {
                   tooltipID={this.props.tooltipID}
                   onClick={this.props.onRefreshClick}
                 />
-                <Popover
-                  align='end'
-                  positions={['bottom', 'left', 'top', 'right']}
-                  padding={0}
-                  content={this.optionsMenu()}
-                  isOpen={this.state.isOptionsMenuOpen}
-                  onClickOutside={() => this.setState({ isOptionsMenuOpen: false })}
-                >
-                  <Button
-                    iconOnly
-                    icon='more-vertical'
-                    border={false}
-                    tooltip='Options'
-                    tooltipID={this.props.tooltipID}
-                    onClick={() => this.setState({ isOptionsMenuOpen: true })}
-                  />
-                </Popover>
+                {this.props.isEditable && (
+                  <Popover
+                    align='end'
+                    positions={['bottom', 'left', 'top', 'right']}
+                    padding={0}
+                    content={this.optionsMenu()}
+                    isOpen={this.state.isOptionsMenuOpen}
+                    onClickOutside={() => this.setState({ isOptionsMenuOpen: false })}
+                  >
+                    <Button
+                      iconOnly
+                      icon='more-vertical'
+                      border={false}
+                      tooltip='Options'
+                      tooltipID={this.props.tooltipID}
+                      onClick={() => this.setState({ isOptionsMenuOpen: true })}
+                    />
+                  </Popover>
+                )}
               </div>
             )}
           </div>

--- a/src/components/DashboardToolbar/DashboardToolbar.js
+++ b/src/components/DashboardToolbar/DashboardToolbar.js
@@ -9,6 +9,7 @@ import { Modal } from '../Modal'
 import { Input } from '../Input'
 
 import './DashboardToolbar.scss'
+import { Icon } from '../Icon'
 
 export class DashboardToolbarWithoutRef extends React.Component {
   static propTypes = {
@@ -123,17 +124,27 @@ export class DashboardToolbarWithoutRef extends React.Component {
           <div className='react-autoql-dashboard-title-and-tools-container'>
             <div className='react-autoql-dashboard-title-container'>
               <div>{this.props.title}</div>
-              <Button
-                className='react-autoql-dashboard-rename-btn'
-                iconOnly
-                icon='edit'
-                border={false}
-                tooltip='Rename Dashboard'
-                tooltipID={this.props.tooltipID}
-                onClick={() => {
-                  this.setState({ isRenameModalOpen: true })
-                }}
-              />
+              {this.props.isEditable ? (
+                <Button
+                  className='react-autoql-dashboard-rename-btn'
+                  iconOnly
+                  icon='edit'
+                  border={false}
+                  tooltip='Rename Dashboard'
+                  tooltipID={this.props.tooltipID}
+                  onClick={() => {
+                    this.setState({ isRenameModalOpen: true })
+                  }}
+                />
+              ) : (
+                <Icon
+                  type='info'
+                  info
+                  tooltip='This Dashboard is static and cannot be edited or removed.'
+                  tooltipID={this.props.tooltipID}
+                  style={{ marginBottom: '3px', marginLeft: '10px' }}
+                />
+              )}
             </div>
             {!this.props.isEditing && (
               <div className='react-autoql-dashboard-title-tools-container'>

--- a/src/components/DashboardToolbar/DashboardToolbar.js
+++ b/src/components/DashboardToolbar/DashboardToolbar.js
@@ -97,12 +97,12 @@ export class DashboardToolbarWithoutRef extends React.Component {
         confirmText='Save'
         confirmDisabled={!this.state.dashboardName}
       >
-        <p>Enter a new name for the dashboard</p>
         <Input
           fullWidth
           ref={(r) => (this.inputRef = r)}
           placeholder='Dashboard Name'
           value={this.state.dashboardName}
+          label='Enter a new name for the dashboard'
           onChange={(e) => this.setState({ dashboardName: e.target.value })}
           onKeyDown={(e) => {
             if (e.key === 'Enter') {

--- a/src/components/DashboardToolbar/DashboardToolbar.js
+++ b/src/components/DashboardToolbar/DashboardToolbar.js
@@ -122,7 +122,7 @@ export class DashboardToolbarWithoutRef extends React.Component {
         >
           <div className='react-autoql-dashboard-title-and-tools-container'>
             <div className='react-autoql-dashboard-title-container'>
-              {this.props.title}
+              <div>{this.props.title}</div>
               <Button
                 className='react-autoql-dashboard-rename-btn'
                 iconOnly

--- a/src/components/DashboardToolbar/DashboardToolbar.js
+++ b/src/components/DashboardToolbar/DashboardToolbar.js
@@ -1,0 +1,91 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Button } from '../Button'
+import { ErrorBoundary } from '../../containers/ErrorHOC'
+
+import './DashboardToolbar.scss'
+
+export class DashboardToolbarWithoutRef extends React.Component {
+  static propTypes = {
+    onSaveClick: PropTypes.func,
+    onCancelClick: PropTypes.func,
+    onDeleteClick: PropTypes.func,
+    onEditClick: PropTypes.func,
+    tooltipID: PropTypes.string,
+    title: PropTypes.string,
+  }
+
+  static defaultProps = {
+    onSaveClick: () => {},
+    onCancelClick: () => {},
+    onDeleteClick: () => {},
+    onEditClick: () => {},
+    tooltipID: undefined,
+    title: 'Untitled Dashboard',
+  }
+
+  render = () => {
+    return (
+      <ErrorBoundary>
+        <div
+          className={`react-autoql-dashboard-toolbar-container
+            ${this.props.isEditing ? 'react-autoql-dashboard-toolbar-container-editing' : ''}`}
+        >
+          <div className='react-autoql-dashboard-title-and-tools-container'>
+            <div className='react-autoql-dashboard-title-container'>
+              {this.props.title}
+              <Button
+                className='react-autoql-dashboard-rename-btn'
+                iconOnly
+                icon='edit'
+                border={false}
+                tooltip='Rename Dashboard'
+                tooltipID={this.props.tooltipID}
+              />
+            </div>
+            {!this.props.isEditing && (
+              <div className='react-autoql-dashboard-title-tools-container'>
+                <Button
+                  iconOnly
+                  icon='refresh'
+                  border={false}
+                  tooltip='Refresh Dashboard Data'
+                  tooltipID={this.props.tooltipID}
+                />
+                <Button
+                  iconOnly
+                  icon='more-vertical'
+                  border={false}
+                  tooltip='Options'
+                  tooltipID={this.props.tooltipID}
+                />
+              </div>
+            )}
+          </div>
+          {this.props.isEditing ? (
+            <div className='react-autoql-dashboard-edit-toolbar-container'>
+              <div className='react-autoql-dashboard-edit-toolbar-container-left'>
+                <Button iconOnly icon='undo' border={false} tooltip='Undo' tooltipID={this.props.tooltipID} />
+                <Button iconOnly icon='redo' border={false} tooltip='Redo' tooltipID={this.props.tooltipID} />
+                <hr className='react-autoql-horizontal-divider' />
+                <Button icon='plus' border={false} tooltip='Add Tile' tooltipID={this.props.tooltipID}>
+                  Add Tile
+                </Button>
+              </div>
+              <div className='react-autoql-dashboard-edit-toolbar-container-right'>
+                <Button border={false} tooltip='Close without saving' tooltipID={this.props.tooltipID}>
+                  Cancel
+                </Button>
+                <Button type='primary' icon='save' tooltip='Save and close' tooltipID={this.props.tooltipID}>
+                  Save
+                </Button>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </ErrorBoundary>
+    )
+  }
+}
+
+export default React.forwardRef((props, ref) => <DashboardToolbarWithoutRef innerRef={ref} {...props} />)

--- a/src/components/DashboardToolbar/DashboardToolbar.js
+++ b/src/components/DashboardToolbar/DashboardToolbar.js
@@ -1,7 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Button } from '../Button'
+import { Menu, MenuItem } from '../Menu'
+import { Popover } from '../Popover'
 import { ErrorBoundary } from '../../containers/ErrorHOC'
+import { ConfirmModal } from '../ConfirmModal'
+import { Modal } from '../Modal'
+import { Input } from '../Input'
 
 import './DashboardToolbar.scss'
 
@@ -11,6 +16,11 @@ export class DashboardToolbarWithoutRef extends React.Component {
     onCancelClick: PropTypes.func,
     onDeleteClick: PropTypes.func,
     onEditClick: PropTypes.func,
+    onRefreshClick: PropTypes.func,
+    onAddTileClick: PropTypes.func,
+    onUndoClick: PropTypes.func,
+    onRedoClick: PropTypes.func,
+    onRenameClick: PropTypes.func,
     tooltipID: PropTypes.string,
     title: PropTypes.string,
   }
@@ -20,8 +30,87 @@ export class DashboardToolbarWithoutRef extends React.Component {
     onCancelClick: () => {},
     onDeleteClick: () => {},
     onEditClick: () => {},
+    onRefreshClick: () => {},
+    onAddTileClick: () => {},
+    onUndoClick: () => {},
+    onRedoClick: () => {},
+    onRenameClick: () => {},
     tooltipID: undefined,
     title: 'Untitled Dashboard',
+  }
+
+  state = {
+    isOptionsMenuOpen: false,
+    isConfirmCloseModalOpen: false,
+    isRenameModalOpen: false,
+    dashboardName: '',
+  }
+
+  componentDidUpdate = (prevProps, prevState) => {
+    if (!prevState.isRenameModalOpen && this.state.isRenameModalOpen) {
+      requestAnimationFrame(() => {
+        this.inputRef?.focus()
+      })
+    } else if (prevState.isRenameModalOpen && !this.state.isRenameModalOpen) {
+      this.setState({ dashboardName: '' })
+    }
+  }
+
+  handleDashboardRename = () => {
+    this.props.onRenameClick(this.state.dashboardName)
+    this.setState({ isRenameModalOpen: false })
+  }
+
+  optionsMenu = () => {
+    return (
+      <Menu>
+        <MenuItem
+          title='Edit Dashboard'
+          icon='edit'
+          onClick={() => {
+            this.props.onEditClick()
+            this.setState({ isOptionsMenuOpen: false })
+          }}
+        />
+        <MenuItem
+          title='Delete Dashboard'
+          icon='trash'
+          style={{ color: 'var(--react-autoql-danger-color)' }}
+          onClick={() => {
+            this.setState({ isOptionsMenuOpen: false, isConfirmDeleteModalVisible: true })
+          }}
+        />
+      </Menu>
+    )
+  }
+
+  renderRenameModal = () => {
+    return (
+      <Modal
+        isVisible={this.state.isRenameModalOpen}
+        onClose={() => this.setState({ isRenameModalOpen: false })}
+        onConfirm={this.handleDashboardRename}
+        title='Rename Dashboard'
+        enableBodyScroll={false}
+        width='400px'
+        confirmText='Save'
+        confirmDisabled={!this.state.dashboardName}
+      >
+        <p>Enter a new name for the dashboard</p>
+        <Input
+          fullWidth
+          ref={(r) => (this.inputRef = r)}
+          placeholder='Dashboard Name'
+          value={this.state.dashboardName}
+          onChange={(e) => this.setState({ dashboardName: e.target.value })}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              this.handleDashboardRename()
+            }
+          }}
+        />
+      </Modal>
+    )
   }
 
   render = () => {
@@ -41,6 +130,9 @@ export class DashboardToolbarWithoutRef extends React.Component {
                 border={false}
                 tooltip='Rename Dashboard'
                 tooltipID={this.props.tooltipID}
+                onClick={() => {
+                  this.setState({ isRenameModalOpen: true })
+                }}
               />
             </div>
             {!this.props.isEditing && (
@@ -51,38 +143,108 @@ export class DashboardToolbarWithoutRef extends React.Component {
                   border={false}
                   tooltip='Refresh Dashboard Data'
                   tooltipID={this.props.tooltipID}
+                  onClick={this.props.onRefreshClick}
                 />
-                <Button
-                  iconOnly
-                  icon='more-vertical'
-                  border={false}
-                  tooltip='Options'
-                  tooltipID={this.props.tooltipID}
-                />
+                <Popover
+                  align='end'
+                  positions={['bottom', 'left', 'top', 'right']}
+                  padding={0}
+                  content={this.optionsMenu()}
+                  isOpen={this.state.isOptionsMenuOpen}
+                  onClickOutside={() => this.setState({ isOptionsMenuOpen: false })}
+                >
+                  <Button
+                    iconOnly
+                    icon='more-vertical'
+                    border={false}
+                    tooltip='Options'
+                    tooltipID={this.props.tooltipID}
+                    onClick={() => this.setState({ isOptionsMenuOpen: true })}
+                  />
+                </Popover>
               </div>
             )}
           </div>
           {this.props.isEditing ? (
             <div className='react-autoql-dashboard-edit-toolbar-container'>
               <div className='react-autoql-dashboard-edit-toolbar-container-left'>
-                <Button iconOnly icon='undo' border={false} tooltip='Undo' tooltipID={this.props.tooltipID} />
-                <Button iconOnly icon='redo' border={false} tooltip='Redo' tooltipID={this.props.tooltipID} />
+                <Button
+                  iconOnly
+                  icon='undo'
+                  border={false}
+                  tooltip='Undo'
+                  tooltipID={this.props.tooltipID}
+                  onClick={this.props.onUndoClick}
+                />
+                <Button
+                  iconOnly
+                  icon='redo'
+                  border={false}
+                  tooltip='Redo'
+                  tooltipID={this.props.tooltipID}
+                  onClick={this.props.onRedoClick}
+                />
                 <hr className='react-autoql-horizontal-divider' />
-                <Button icon='plus' border={false} tooltip='Add Tile' tooltipID={this.props.tooltipID}>
+                <Button
+                  icon='plus'
+                  border={false}
+                  tooltip='Add Tile'
+                  tooltipID={this.props.tooltipID}
+                  onClick={this.props.onAddTileClick}
+                >
                   Add Tile
                 </Button>
               </div>
               <div className='react-autoql-dashboard-edit-toolbar-container-right'>
-                <Button border={false} tooltip='Close without saving' tooltipID={this.props.tooltipID}>
+                <Button
+                  border={false}
+                  tooltip='Close without saving'
+                  tooltipID={this.props.tooltipID}
+                  onClick={() => this.setState({ isConfirmCloseModalOpen: true })}
+                >
                   Cancel
                 </Button>
-                <Button type='primary' icon='save' tooltip='Save and close' tooltipID={this.props.tooltipID}>
+                <Button
+                  type='primary'
+                  icon='save'
+                  tooltip='Save and close'
+                  tooltipID={this.props.tooltipID}
+                  onClick={this.props.onSaveClick}
+                >
                   Save
                 </Button>
               </div>
             </div>
           ) : null}
         </div>
+        <ConfirmModal
+          isVisible={this.state.isConfirmCloseModalOpen}
+          onClose={() => this.setState({ isConfirmCloseModalOpen: false })}
+          confirmText='Discard Changes'
+          onConfirm={() => {
+            this.props.onCancelClick()
+            this.setState({ isConfirmCloseModalOpen: false })
+          }}
+        >
+          <h3>Are you sure you want to leave?</h3>
+          <p>Any unsaved changes will be lost.</p>
+        </ConfirmModal>
+        <ConfirmModal
+          isVisible={this.state.isConfirmDeleteModalVisible}
+          onClose={() => this.setState({ isConfirmDeleteModalVisible: false })}
+          confirmText='Delete Dashboard'
+          onConfirm={() => {
+            this.props.onDeleteClick()
+            this.setState({ isConfirmDeleteModalVisible: false })
+          }}
+        >
+          <h3>Are you sure you want to delete this Dashboard?</h3>
+          <p>
+            This will permanently delete this Dashboard and all Tiles housed within it. This action cannot be undone. Do
+            you wish to continue?
+          </p>
+        </ConfirmModal>
+        {this.renderRenameModal()}
       </ErrorBoundary>
     )
   }

--- a/src/components/DashboardToolbar/DashboardToolbar.scss
+++ b/src/components/DashboardToolbar/DashboardToolbar.scss
@@ -18,7 +18,7 @@
     .react-autoql-dashboard-title-container {
       display: flex;
       justify-content: flex-start;
-      align-items: flex-end;
+      align-items: center;
       font-size: 20px;
       font-weight: 600;
 

--- a/src/components/DashboardToolbar/DashboardToolbar.scss
+++ b/src/components/DashboardToolbar/DashboardToolbar.scss
@@ -1,5 +1,5 @@
 .react-autoql-dashboard-toolbar-container {
-  padding: 10px 10px 10px 24px;
+  padding: 15px 10px 10px 24px;
   top: 0;
   left: auto;
   right: 0;

--- a/src/components/DashboardToolbar/DashboardToolbar.scss
+++ b/src/components/DashboardToolbar/DashboardToolbar.scss
@@ -48,7 +48,7 @@
 
   &.react-autoql-dashboard-toolbar-container-editing {
     .react-autoql-dashboard-rename-btn {
-      opacity: 1;
+      opacity: 1 !important;
     }
   }
 

--- a/src/components/DashboardToolbar/DashboardToolbar.scss
+++ b/src/components/DashboardToolbar/DashboardToolbar.scss
@@ -1,0 +1,67 @@
+.react-autoql-dashboard-toolbar-container {
+  padding: 10px 10px 10px 24px;
+  top: 0;
+  left: auto;
+  right: 0;
+  position: sticky;
+  background: var(--react-autoql-background-color-primary);
+  z-index: 1000;
+
+  .react-autoql-dashboard-title-and-tools-container {
+    display: flex;
+    flex-wrap: nowrap;
+    max-width: 100%;
+    align-items: center;
+    justify-content: space-between;
+    overflow: hidden;
+
+    .react-autoql-dashboard-title-container {
+      display: flex;
+      justify-content: flex-start;
+      align-items: flex-end;
+      font-size: 20px;
+      font-weight: 600;
+
+      .react-autoql-dashboard-rename-btn {
+        margin: 0 !important;
+        padding: 0 !important;
+        margin-left: 3px !important;
+        font-size: 15px;
+        opacity: 0;
+      }
+
+      &:hover .react-autoql-dashboard-rename-btn {
+        opacity: 1;
+      }
+    }
+
+    .react-autoql-dashboard-title-tools-container {
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+
+      .react-autoql-btn {
+        color: var(--react-autoql-text-color-primary);
+      }
+    }
+  }
+
+  &.react-autoql-dashboard-toolbar-container-editing {
+    .react-autoql-dashboard-rename-btn {
+      opacity: 1;
+    }
+  }
+
+  .react-autoql-dashboard-edit-toolbar-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    margin-top: 5px;
+
+    .react-autoql-dashboard-edit-toolbar-container-left,
+    .react-autoql-dashboard-edit-toolbar-container-right {
+      display: flex;
+      justify-content: center;
+    }
+  }
+}

--- a/src/components/DashboardToolbar/index.js
+++ b/src/components/DashboardToolbar/index.js
@@ -1,0 +1,1 @@
+export { default as DashboardToolbar } from './DashboardToolbar'

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -51,6 +51,7 @@ import { FiMinimize } from '@react-icons/all-files/fi/FiMinimize'
 import { FiRefreshCw } from '@react-icons/all-files/fi/FiRefreshCw'
 import { FiTool } from '@react-icons/all-files/fi/FiTool'
 import { FiMinus } from '@react-icons/all-files/fi/FiMinus'
+import { FiSave } from 'react-icons/fi'
 import { RiFilterLine } from '@react-icons/all-files/ri/RiFilterLine'
 import { RiFilterOffLine } from '@react-icons/all-files/ri/RiFilterOffLine'
 import { RiListSettingsLine } from '@react-icons/all-files/ri/RiListSettingsLine'
@@ -77,6 +78,7 @@ import { MdLockOpen } from '@react-icons/all-files/md/MdLockOpen'
 import { MdPlayCircleOutline } from '@react-icons/all-files/md/MdPlayCircleOutline'
 import { MdAttachMoney } from '@react-icons/all-files/md/MdAttachMoney'
 import { MdFunctions } from '@react-icons/all-files/md/MdFunctions'
+import { MdOutlineUndo, MdOutlineRedo } from 'react-icons/md'
 
 import { RxOpenInNewWindow } from 'react-icons/rx'
 import { TfiArrowsCorner } from 'react-icons/tfi'
@@ -158,6 +160,10 @@ export default class Icon extends React.Component {
       }
       case 'bookmark': {
         icon = <BiBookmark />
+        break
+      }
+      case 'save': {
+        icon = <FiSave />
         break
       }
       case 'scatterplot': {
@@ -452,6 +458,10 @@ export default class Icon extends React.Component {
         icon = <AiOutlineQuestionCircle />
         break
       }
+      case 'redo': {
+        icon = <MdOutlineRedo />
+        break
+      }
       case 'refresh': {
         icon = <FiRefreshCw />
         break
@@ -515,6 +525,10 @@ export default class Icon extends React.Component {
       }
       case 'select-multiple': {
         icon = <BiSelectMultiple />
+        break
+      }
+      case 'undo': {
+        icon = <MdOutlineUndo />
         break
       }
       case 'unlock': {

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -556,6 +556,7 @@ export default class Icon extends React.Component {
           className={`react-autoql-icon
             ${this.props.className || ''}
             react-autoql-icon-${this.props.type}
+            ${this.props.info ? 'react-autoql-icon-info' : ''}
             ${this.props.warning ? 'react-autoql-icon-warning' : ''}
             ${this.props.success ? 'react-autoql-icon-success' : ''}
             ${this.props.danger ? 'react-autoql-icon-danger' : ''}

--- a/src/components/Icon/Icon.scss
+++ b/src/components/Icon/Icon.scss
@@ -12,6 +12,9 @@
   &.react-autoql-icon-success {
     color: var(--react-autoql-success-color) !important;
   }
+  &.react-autoql-icon-info {
+    color: var(--react-autoql-accent-color) !important;
+  }
   &.react-autoql-icon-warning {
     color: var(--react-autoql-warning-color) !important;
   }

--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -21,6 +21,7 @@ export class MenuItem extends React.Component {
     tooltip: PropTypes.string,
     tooltipID: PropTypes.string,
     disabled: PropTypes.bool,
+    style: PropTypes.shape({}),
     onClick: PropTypes.func,
   }
 
@@ -32,12 +33,14 @@ export class MenuItem extends React.Component {
     tooltip: undefined,
     tooltipID: undefined,
     disabled: false,
+    style: {},
     onClick: () => {},
   }
 
   render = () => {
     return (
       <li
+        style={this.props.style}
         id={this.props.id ?? `react-autoql-menu-item-${this.ID}`}
         key={`react-autoql-menu-item-${this.ID}`}
         className={`react-autoql-menu-item

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -94,7 +94,7 @@ export default class Modal extends React.Component {
     return (
       <div className='modal-footer-button-container right'>
         {this.props.showCancelButton && (
-          <Button type='default' onClick={this.onClose}>
+          <Button type='default' onClick={this.onClose} border={false}>
             Cancel
           </Button>
         )}

--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -127,7 +127,7 @@
 
 .react-autoql-modal-header {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   position: relative;
   border-bottom: 1px solid var(--react-autoql-border-color, rgba(0, 0, 0, 0.05));
 
@@ -139,10 +139,11 @@
 
   .react-autoql-modal-header-title {
     display: flex;
-    justify-content: center;
+    justify-content: flex-start;
     align-items: center;
     font-size: 17px;
-    margin: 3px;
+    margin-left: 20px;
+    font-weight: 600;
 
     .react-autoql-icon {
       margin-right: 5px;
@@ -181,7 +182,6 @@
   flex: 0;
   font-size: 22px;
   margin: 16px;
-  padding-left: 15px;
   opacity: 0.6 !important;
   cursor: pointer;
   box-sizing: content-box;

--- a/src/index.scss
+++ b/src/index.scss
@@ -19,6 +19,16 @@
   opacity: 0;
 }
 
+.react-autoql-horizontal-divider {
+  width: 1px;
+  height: 70%;
+  margin: auto 16px;
+  background-color: #0000001f;
+  align-self: stretch;
+  border: none;
+  flex-shrink: 0;
+}
+
 @keyframes pulse {
   0% {
     opacity: 0.05;


### PR DESCRIPTION
I put all dashboard tools into a react-autoql widget. This is to prepare for the eventual feature of dashboard slicing when we will want to add more complex tools to the toolbar. Then we can reuse these tools elsewhere outside of webapp.