### PR TITLE
Feature qei dm custom toolbar option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-autoql",
-  "version": "8.27.4",
+  "version": "8.27.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-autoql",
-      "version": "8.27.4",
+      "version": "8.27.5",
       "license": "ISC",
       "dependencies": {
         "@react-icons/all-files": "4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-autoql",
-  "version": "8.27.5",
+  "version": "8.27.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-autoql",
-      "version": "8.27.5",
+      "version": "8.27.6",
       "license": "ISC",
       "dependencies": {
         "@react-icons/all-files": "4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-autoql",
-  "version": "8.27.6",
+  "version": "8.28.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-autoql",
-      "version": "8.27.6",
+      "version": "8.28.1",
       "license": "ISC",
       "dependencies": {
         "@react-icons/all-files": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-autoql",
-  "version": "8.27.6",
+  "version": "8.28.1",
   "description": "React Widget Library",
   "main": "dist/autoql.cjs.js",
   "module": "dist/autoql.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-autoql",
-  "version": "8.27.5",
+  "version": "8.27.6",
   "description": "React Widget Library",
   "main": "dist/autoql.cjs.js",
   "module": "dist/autoql.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-autoql",
-  "version": "8.27.4",
+  "version": "8.27.5",
   "description": "React Widget Library",
   "main": "dist/autoql.cjs.js",
   "module": "dist/autoql.esm.js",

--- a/src/components/DataMessenger/DataMessenger.js
+++ b/src/components/DataMessenger/DataMessenger.js
@@ -164,6 +164,8 @@ export class DataMessenger extends React.Component {
     onSuccessAlert: PropTypes.func,
     setMobileActivePage: PropTypes.func,
     onProjectSelectChange: PropTypes.func,
+    onCreateQueryEvaluationItem: PropTypes.func,
+    queryItemActionName: PropTypes.string,
   }
 
   static defaultProps = {
@@ -222,6 +224,8 @@ export class DataMessenger extends React.Component {
     onErrorCallback: () => {},
     onSuccessAlert: () => {},
     onProjectSelectChange: () => {},
+    onCreateQueryEvaluationItem: undefined,
+    queryItemActionName: 'Add Query Evaluation Item',
   }
 
   componentDidMount = () => {
@@ -476,6 +480,34 @@ export class DataMessenger extends React.Component {
 
   onTopicClick = (...params) => {
     this.dataMessengerContentRef?.animateInputTextAndSubmit(...params)
+  }
+
+  getCustomToolbarOptions = () => {
+    const customToolbarOptions = [...(this.props.customToolbarOptions || [])]
+    if (!this.props.onCreateQueryEvaluationItem) {
+      return customToolbarOptions
+    }
+
+    return [
+      ...customToolbarOptions,
+      {
+        name: this.props.queryItemActionName || 'Add Query Evaluation Item',
+        icon: 'plus',
+        callback: async (queryToolbarPayload) => {
+          try {
+            await this.props.onCreateQueryEvaluationItem(queryToolbarPayload)
+            this.props.onSuccessAlert?.(`${this.props.queryItemActionName || 'Add Query Evaluation Item'} succeeded.`)
+          } catch (error) {
+            console.error(error)
+            this.props.onErrorCallback?.(
+              error?.response?.data?.data ||
+                error?.message ||
+                'Failed to create Query Evaluation Item.',
+            )
+          }
+        },
+      },
+    ]
   }
 
   handleClearQueriesDropdown = () => {
@@ -849,7 +881,7 @@ export class DataMessenger extends React.Component {
           tooltipID={this.TOOLTIP_ID}
           chartTooltipID={this.CHART_TOOLTIP_ID}
           scope={this.props.scope}
-          customToolbarOptions={this.props.customToolbarOptions}
+          customToolbarOptions={this.getCustomToolbarOptions()}
           enableCustomColumns={this.props.enableCustomColumns}
           disableAggregationMenu={this.props.disableAggregationMenu}
           allowCustomColumnsOnDrilldown={this.props.allowCustomColumnsOnDrilldown}


### PR DESCRIPTION
- DataMessenger now accepts onCreateQueryEvaluationItem as a top-level prop (outside autoQLConfig).
- DataMessenger now accepts queryItemActionName as a top-level prop (outside autoQLConfig).
- queryItemActionName defaults to 'Add Query Evaluation Item'.
- A custom query toolbar action is injected only when onCreateQueryEvaluationItem is provided.
- The injected action executes onCreateQueryEvaluationItem(queryToolbarPayload)