### PR TITLE
Strip empty pivot/table configs to avoid blank tile

### DIFF
--- a/src/components/Dashboard/DashboardTile/DashboardTile.js
+++ b/src/components/Dashboard/DashboardTile/DashboardTile.js
@@ -1916,9 +1916,24 @@ export class DashboardTile extends React.Component {
               }
             })
           }
+          // If pivotTableConfig has all empty index arrays it was saved before the data was
+          // properly initialized (e.g. readonly tile whose config was never generated).
+          // Strip both pivotTableConfig and tableConfig so QueryOutput regenerates them fresh
+          // from the actual response columns — an empty config causes pivotTableData = [] and
+          // a completely blank tile.
+          const ptc = dataConfig?.pivotTableConfig
+          const pivotConfigIsEmpty =
+            ptc &&
+            !ptc.numberColumnIndices?.length &&
+            !ptc.stringColumnIndices?.length
+
+          const { pivotTableConfig, tableConfig, ...restDataConfig } = dataConfig
+
           return {
-            ...dataConfig,
+            ...restDataConfig,
             columnOverrides,
+            ...(!pivotConfigIsEmpty && pivotTableConfig !== undefined ? { pivotTableConfig } : {}),
+            ...(!pivotConfigIsEmpty && tableConfig !== undefined ? { tableConfig } : {}),
           }
         })(),
         initialAggConfig: this.props.tile.aggConfig,


### PR DESCRIPTION
Detect when dataConfig.pivotTableConfig contains empty index arrays (e.g. saved before data was initialized) and treat that as empty. Destructure out pivotTableConfig and tableConfig and only re-include them when they are present and not empty; otherwise omit them so QueryOutput will regenerate configs from the actual response columns. This prevents pivotTableData from becoming [] and producing a completely blank dashboard tile for uninitialized configs.